### PR TITLE
Don't enumerate fields on generic type Def

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -136,21 +136,28 @@ namespace System.Diagnostics
                 {
                     if (methodName == ".cctor")
                     {
-                        var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-                        foreach (var field in fields)
+                        if (type.IsGenericTypeDefinition && !type.IsConstructedGenericType)
                         {
-                            var value = field.GetValue(field);
-                            if (value is Delegate d)
+                            var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                            foreach (var field in fields)
                             {
-                                if (ReferenceEquals(d.Method, originMethod) &&
-                                    d.Target.ToString() == originMethod.DeclaringType.ToString())
-                                {
-                                    methodDisplayInfo.Name = field.Name;
-                                    methodDisplayInfo.IsLambda = false;
-                                    method = originMethod;
-                                    break;
+                                    var value = field.GetValue(field);
+                                    if (value is Delegate d)
+                                    {
+                                        if (ReferenceEquals(d.Method, originMethod) &&
+                                            d.Target.ToString() == originMethod.DeclaringType.ToString())
+                                        {
+                                            methodDisplayInfo.Name = field.Name;
+                                            methodDisplayInfo.IsLambda = false;
+                                            method = originMethod;
+                                            break;
+                                        }
+                                    }
                                 }
                             }
+                        else
+                        {
+                            // TODO: diagnose type's generic type arguments from frame's "this" or something
                         }
                     }
                 }


### PR DESCRIPTION
Prevent exception being thrown when generic type definition is not a constructed generic type when trying to retrieve field values.
Added TODO with suggestion as to how to diagnose type arguments for generic type definition to create a constructed generic type.